### PR TITLE
Support matching libraries but diff Shellcore

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -126,13 +126,24 @@ namespace PS4Saves
         private void matchExactFWVersion(int fwVersion)
         {
             String detectedFirmware = ((double)fwVersion / 100).ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
-            Offsets.SelectedFirmware = detectedFirmware;
+            Offsets.SelectedFirmwareLibraries = detectedFirmware;
+            Offsets.SelectedFirmwareShellcore = detectedFirmware;
             label2.Text += " " + detectedFirmware;
         }
-        private void matchLooseFWVersion(int fwVersion, String relatedFwVersion, bool offsetsWarning = true)
+        private void matchLooseFWVersion(int fwVersion, String relatedFwVersion, bool offsetsWarning = true, bool differentShellcorePatches = false)
         {
             String detectedFirmware = ((double)fwVersion / 100).ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
-            Offsets.SelectedFirmware = relatedFwVersion;
+            Offsets.SelectedFirmwareLibraries = relatedFwVersion;
+
+            if (differentShellcorePatches)
+            {
+                Offsets.SelectedFirmwareShellcore = detectedFirmware;
+            }
+            else
+            {
+                Offsets.SelectedFirmwareShellcore = relatedFwVersion;
+            }
+            
             if (offsetsWarning)
             {
                 label2.Text += " " + detectedFirmware + ". Using FW " + relatedFwVersion + " offsets that might not work";
@@ -210,6 +221,10 @@ namespace PS4Saves
                 if (version == 320 || version == 403 || version == 502 || version == 602 || version == 740 || version == 820 || version == 960 || version == 1001)
                 {
                     matchExactFWVersion(version);
+                }
+                else if (version == 550) // same as 5.02, different shellcore patches
+                {
+                    matchLooseFWVersion(version, "5.02", false, true);
                 }
                 else if (version == 940) // same as 9.60
                 {
@@ -354,7 +369,7 @@ namespace PS4Saves
 
             ps4.ChangeProtection(shellcore.pid, ex.start, (uint)(ex.end - ex.start), PS4DBG.VM_PROTECTIONS.VM_PROT_ALL);
 
-            List<Patch> patchesToApply = Patches.GetShellcorePatches(Offsets.SelectedFirmware);
+            List<Patch> patchesToApply = Patches.GetShellcorePatches(Offsets.SelectedFirmwareShellcore);
 
             if (patchesToApply.Count > 0) // Check if there are any patches to apply
             {
@@ -397,7 +412,7 @@ namespace PS4Saves
 
             ps4.WriteMemory(pid, GetSaveDirectoriesAddr, functions.GetSaveDirectories);
 
-            List<Patch> patchesToApply = Patches.GetLibcPatches(Offsets.SelectedFirmware);
+            List<Patch> patchesToApply = Patches.GetLibcPatches(Offsets.SelectedFirmwareShellcore);
 
             if (patchesToApply.Count > 0) // Check if there are any patches to apply
             {
@@ -845,7 +860,7 @@ namespace PS4Saves
             // Change memory mapping to RWX
             ps4.ChangeProtection(shellcore.pid, ex.start, (uint)(ex.end - ex.start), PS4DBG.VM_PROTECTIONS.VM_PROT_ALL);
 
-            List<Patch> patchesToApply = Patches.GetShellcorePatches(Offsets.SelectedFirmware);
+            List<Patch> patchesToApply = Patches.GetShellcorePatches(Offsets.SelectedFirmwareShellcore);
 
             if (patchesToApply.Count > 0) // Check if there are any patches to apply
             {

--- a/Offsets.cs
+++ b/Offsets.cs
@@ -4,10 +4,10 @@ namespace PS4Saves;
 
 public static class Offsets
 {
-    public static readonly string[] Firmwares = ["3.20", "7.40", "8.20", "10.01"];
-    public static string SelectedFirmware { get; set; } = string.Empty; // updated by Connect button
-  
-    public static ulong sceUserServiceGetInitialUser => SelectedFirmware switch
+    public static string SelectedFirmwareLibraries { get; set; } = string.Empty; // updated by Connect button
+    public static string SelectedFirmwareShellcore { get; set; } = string.Empty; // updated by Connect button
+
+    public static ulong sceUserServiceGetInitialUser => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x32E0,
         "3.20" => 0x32D0,
@@ -21,7 +21,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceUserServiceGetLoginUserIdList => SelectedFirmware switch
+    public static ulong sceUserServiceGetLoginUserIdList => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x2A50,
         "3.20" => 0x2A50,
@@ -35,7 +35,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceUserServiceGetUserName => SelectedFirmware switch
+    public static ulong sceUserServiceGetUserName => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x46A0,
         "3.20" => 0x4690,
@@ -49,7 +49,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceSaveDataMount => SelectedFirmware switch
+    public static ulong sceSaveDataMount => SelectedFirmwareLibraries switch
     {
         //"2.50" => 0x2FE00,
         "3.20" => 0x31DB0,
@@ -63,7 +63,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceSaveDataUmount => SelectedFirmware switch
+    public static ulong sceSaveDataUmount => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x302D0,
         "3.20" => 0x32560,
@@ -77,7 +77,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceSaveDataDirNameSearch => SelectedFirmware switch
+    public static ulong sceSaveDataDirNameSearch => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x310B0,
         "3.20" => 0x33340,
@@ -91,7 +91,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceSaveDataTransferringMount => SelectedFirmware switch
+    public static ulong sceSaveDataTransferringMount => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x30180,
         "3.20" => 0x32410,
@@ -105,7 +105,7 @@ public static class Offsets
         _ => throw new Exception("Unsupported firmware (did you select an item from the dropdown?)")
     };
 
-    public static ulong sceSaveDataInitialize3 => SelectedFirmware switch
+    public static ulong sceSaveDataInitialize3 => SelectedFirmwareLibraries switch
     {
         "2.50" => 0x2F970,
         "3.20" => 0x31C00,

--- a/Patches.cs
+++ b/Patches.cs
@@ -114,6 +114,33 @@ public static class Patches
             }
         },
         {
+            "5.50", new List<Patch>[]
+            {
+                // Shellcore patches
+                [
+                    new(0x183F338, [0x00]), // 'sce_sdmemory' patch
+                    new(0x18366E9, [0x00]), // 'sce_sdmemory1' patch
+                    new(0x18366F7, [0x00]), // 'sce_sdmemory2' patch
+                    new(0x18D792E, [0x00]), // 'sce_sdmemory3' patch
+                    new(0xBD1D60, [0x48, 0x31, 0xC0, 0xC3]), // verify keystone patch
+                    new(0x1138E0, [0x31, 0xC0, 0xC3]), // transfer mount permission patch eg mount foreign saves with write permission
+                    new(0x1AAF90, [0x31, 0xC0, 0xC3]), // patch psn check to load saves saves foreign to current account
+                    new(0x117774, [0xE9, 0x0C, 0x00, 0x00, 0x00]), // ^ (thanks to GRModSave_Username) different patch
+                    new(0x115E38, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // something something patches...
+                    new(0x113C6C, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // don't even remember doing this
+                    new(0x113344, [0x90, 0x90]), // nevah jump
+                    new(0x1135F3, [0x90, 0xE9]) // alays jump
+                ],
+                // Libc patches
+                [
+                    new(0x12, 0x76FD0), // opendir
+                    new(0x20, 0x76E80), // readdir
+                    new(0x2E, 0x76B90), // closedir
+                    new(0x3C, 0x78C90)  // strcpy
+                ]
+            }
+        },
+        {
             "6.02", new List<Patch>[]
             {
                 // Shellcore patches
@@ -191,6 +218,60 @@ public static class Patches
                     new(0x20, 0x75F50), // readdir
                     new(0x2E, 0x75C80), // closedir
                     new(0x3C, 0x77D20)  // strcpy
+                ]
+            }
+        },
+        {
+            "8.40", new List<Patch>[]
+            {
+                // Shellcore patches
+                [
+                    new(0x1B219EF, [0x00]), // 'sce_sdmemory' patch
+                    new(0x1B823EC, [0x00]), // 'sce_sdmemory1' patch
+                    new(0x1B3770B, [0x00]), // 'sce_sdmemory2' patch
+                    new(0x1AD7E63, [0x00]), // 'sce_sdmemory3' patch
+                    new(0xD66930, [0x48, 0x31, 0xC0, 0xC3]), // verify keystone patch
+                    new(0x11F1B0, [0x31, 0xC0, 0xC3]), // transfer mount permission patch eg mount foreign saves with write permission
+                    new(0x1D2660, [0x31, 0xC0, 0xC3]), // patch psn check to load saves saves foreign to current account
+                    new(0x122EAA, [0xE9, 0x05, 0x00, 0x00]), // ^ (thanks to GRModSave_Username) different patch
+                    new(0x121598, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // something something patches...
+                    new(0x122281, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // don't even remember doing this
+                    new(0x11EC24, [0x90, 0x90]), // nevah jump
+                    new(0x11EEC7, [0x90, 0xE9]) // always jump
+                ],
+                // Libc patches
+                [
+                    new(0x12, 0), // opendir
+                    new(0x20, 0), // readdir
+                    new(0x2E, 0), // closedir
+                    new(0x3C, 0)  // strcpy
+                ]
+            }
+        },
+        {
+            "8.60", new List<Patch>[]
+            {
+                // Shellcore patches
+                [
+                    new(0x1B2635B, [0x00]), // 'sce_sdmemory' patch
+                    new(0x1B86AFF, [0x00]), // 'sce_sdmemory1' patch
+                    new(0x1B3BDED, [0x00]), // 'sce_sdmemory2' patch
+                    new(0x1ADC881, [0x00]), // 'sce_sdmemory3' patch
+                    new(0xD66930, [0x48, 0x31, 0xC0, 0xC3]), // verify keystone patch
+                    new(0x11F1B0, [0x31, 0xC0, 0xC3]), // transfer mount permission patch eg mount foreign saves with write permission
+                    new(0x1D2660, [0x31, 0xC0, 0xC3]), // patch psn check to load saves saves foreign to current account
+                    new(0x122EAA, [0xE9, 0x05, 0x00, 0x00]), // ^ (thanks to GRModSave_Username) different patch
+                    new(0x121598, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // something something patches...
+                    new(0x122281, [0x90, 0x90, 0x90, 0x90, 0x90, 0x90]), // don't even remember doing this
+                    new(0x11EC24, [0x90, 0x90]), // nevah jump
+                    new(0x11EEC7, [0x90, 0xE9]) // always jump
+                ],
+                // Libc patches
+                [
+                    new(0x12, 0), // opendir
+                    new(0x20, 0), // readdir
+                    new(0x2E, 0), // closedir
+                    new(0x3C, 0)  // strcpy
                 ]
             }
         },


### PR DESCRIPTION
Some firmwares have exact libraries offsets but different Shellcore patches offsets. Support those without duplicating libraries offsets.